### PR TITLE
feat: enforce pdt equity check in risk manager

### DIFF
--- a/market_sage_pro/risk/manager.py
+++ b/market_sage_pro/risk/manager.py
@@ -25,6 +25,12 @@ class RiskManager:
             return False
         if open_symbol_exposure_pct >= self.cfg.per_symbol_cap_pct:
             return False
-        if is_pdt_restricted:
+        # Reject if the account is flagged for pattern day trading or
+        # falls below the regulatory $25k equity requirement.  The
+        # previous implementation only honored the ``is_pdt_restricted``
+        # flag, allowing accounts with low equity to open new positions
+        # if the flag was not set.  This check makes the behaviour
+        # robust by also validating the equity value.
+        if is_pdt_restricted or equity_usd < 25_000:
             return False
         return True

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -11,3 +11,10 @@ def test_risk_manager_circuit_breaker():
 def test_risk_manager_per_symbol_cap():
     rm = RiskManager(RiskConfig(max_daily_loss_pct=-2))
     assert not rm.can_open_new(100000, 5.0, False)
+
+
+def test_risk_manager_pdt_equity_check():
+    rm = RiskManager(RiskConfig(max_daily_loss_pct=-2))
+    # Equity below $25k should prevent opening new positions even if the
+    # caller forgets to set is_pdt_restricted.
+    assert not rm.can_open_new(24_000, 0, False)


### PR DESCRIPTION
## Summary
- ensure RiskManager blocks new positions when equity falls below $25k even if `is_pdt_restricted` flag is missing
- add tests for PDT equity check

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689681ba7878832ea56d1fa5f85fb5f1