### PR TITLE
Add Alpaca endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ No Financial Advice. Trade at Your Own Risk.
 ```bash
 cp config.yaml.example config.yaml
 ```
-Fill `alpaca_key/secret` (paper by default), `max_daily_loss_pct`, `kelly_fraction_cap`, optional `telegram_bot_token/chat_id`.
+Fill `alpaca_key/secret` and optionally `alpaca_endpoint` (default `https://paper-api.alpaca.markets/v2`), `max_daily_loss_pct`, `kelly_fraction_cap`, optional `telegram_bot_token/chat_id`.
 
 3) Run services
 ```bash

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,6 +1,7 @@
 # MarketSage-Pro config
 alpaca_key: "YOUR_ALPACA_KEY"
 alpaca_secret: "YOUR_ALPACA_SECRET"
+alpaca_endpoint: "https://paper-api.alpaca.markets/v2"
 max_daily_loss_pct: -2
 kelly_fraction_cap: 0.5
 telegram_bot_token: ""

--- a/market_sage_pro/config.py
+++ b/market_sage_pro/config.py
@@ -17,6 +17,7 @@ logger = get_logger(__name__)
 class AppConfig(BaseModel):
     alpaca_key: str
     alpaca_secret: str
+    alpaca_endpoint: str = "https://paper-api.alpaca.markets/v2"
     max_daily_loss_pct: float = Field(..., le=0)
     kelly_fraction_cap: float = Field(..., ge=0, le=1)
     telegram_bot_token: str | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ def test_app_config_validation():
         kelly_fraction_cap=0.5,
     )
     assert cfg.max_daily_loss_pct == -2
+    assert cfg.alpaca_endpoint == "https://paper-api.alpaca.markets/v2"
 
     with pytest.raises(Exception):
         AppConfig(


### PR DESCRIPTION
## Summary
- Allow configuring Alpaca API endpoint with default paper trading URL
- Document new `alpaca_endpoint` field in README and example config
- Test `AppConfig` for default endpoint value

## Testing
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a9e1bb4c832eb3cda0f1f3832c36