### PR TITLE
Slim Docker build contexts for scheduler and UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+**/__pycache__
+*.py[cod]
+.DS_Store
+docs/
+tests/
+notebooks/
+postman/
+ui/node_modules/
+

--- a/scheduler.Dockerfile
+++ b/scheduler.Dockerfile
@@ -6,5 +6,6 @@ ENV PYTHONUNBUFFERED=1
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . /app
+COPY market_sage_pro/ /app/market_sage_pro/
+COPY config.yaml.example /app/
 CMD ["python", "-m", "market_sage_pro.scheduler.jobs"]

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+.DS_Store
+npm-debug.log*

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,14 +1,16 @@
-# FROM node:20-alpine      # <- switch this out if you had it
-
-FROM node:20              
- # <- use this for a more complete image with npm, git, etc.]
+FROM node:20
 
 WORKDIR /app
-COPY package.json /app/package.json
-RUN npm install
-COPY . /app
 
-# expose vite port if you want
+COPY package*.json ./
+RUN npm ci
+
+COPY src ./src
+COPY index.html ./
+COPY vite.config.ts ./
+COPY postcss.config.js ./
+COPY tailwind.config.js ./
+
 EXPOSE 5173
 
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add repository-level `.dockerignore` to trim build context
- Copy only required project files in `scheduler.Dockerfile`
- Tighten UI image build with its own `.dockerignore` and selective file copies

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `apt-get install -y docker-compose`
- `docker-compose build scheduler` *(fails: Error while fetching server API version)*
- `docker-compose build ui` *(fails: Connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6899727df7a0832e9488d026b45cc7f3