### PR TITLE
Expose backtest endpoint and UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pytest-asyncio==1.1.0
 httpx==0.28.1
 ruff==0.12.8
 mypy==1.17.1
+pandas==2.2.3

--- a/tests/backtest/test_engine.py
+++ b/tests/backtest/test_engine.py
@@ -1,0 +1,34 @@
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from market_sage_pro.backtest.engine import backtest
+from market_sage_pro.signals.generator import SignalConfig
+
+
+def test_backtest_metrics() -> None:
+    idx = pd.date_range('2023-01-01', periods=2, freq='B')
+    df = pd.DataFrame({
+        'p_up': [0.8, 0.2],
+        'p_down': [0.2, 0.8],
+        'pred_move': [0.5, -0.5],
+        'rsi': [50, 50],
+        'px_vs_ema21': [0.1, -0.1],
+        'ivr': [0.5, 0.5],
+        'p_big': [0.7, 0.7],
+        'actual_move': [1.0, -0.5],
+    }, index=idx)
+
+    res = backtest(df, SignalConfig(kelly_fraction_cap=0.5))
+
+    assert res['trades'] == 2
+    assert res['win_rate'] == 0.5
+    assert res['equity'] == pytest.approx(1.00238848, rel=1e-6)
+    assert res['max_drawdown'] == pytest.approx(0.0024, abs=1e-6)
+    assert res['profit_factor'] == pytest.approx(2.0, rel=1e-6)
+    assert math.isnan(res['Sortino'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,14 +3,14 @@ from fastapi.testclient import TestClient
 from market_sage_pro.api.main import app
 
 
-def test_health():
+def test_health() -> None:
     client = TestClient(app)
     r = client.get('/health')
     assert r.status_code == 200
     assert r.json()['status'] == 'ok'
 
 
-def test_signal_endpoint():
+def test_signal_endpoint() -> None:
     client = TestClient(app)
     r = client.post('/signal', json={
         'ensemble_up_prob': 0.7,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,9 +2,39 @@ import React, { useEffect, useState } from 'react'
 
 export const App: React.FC = () => {
   const [health, setHealth] = useState<string>('')
+  const [fromDate, setFromDate] = useState<string>('')
+  const [toDate, setToDate] = useState<string>('')
+  const [symbols, setSymbols] = useState<string>('')
+  const [results, setResults] = useState<any | null>(null)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string>('')
   useEffect(() => {
     fetch('http://localhost:8000/health').then(r => r.json()).then(j => setHealth(j.status))
   }, [])
+
+  const runBacktest = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setResults(null)
+    try {
+      const resp = await fetch('http://localhost:8000/backtest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from_date: fromDate,
+          to_date: toDate || 'today',
+          symbols: symbols.split(',').map(s => s.trim()).filter(Boolean)
+        })
+      })
+      if (!resp.ok) throw new Error('Request failed')
+      setResults(await resp.json())
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
   return (
     <div className="p-4 font-sans">
       <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4">
@@ -20,8 +50,31 @@ export const App: React.FC = () => {
         <div className="p-4 border rounded">IVR Meter (placeholder)</div>
       </div>
 
-      <div className="p-4 border rounded mt-4">Trade Log (placeholder)</div>
-      <div className="p-4 border rounded mt-4">Control Center (placeholder)</div>
+      <form onSubmit={runBacktest} className="p-4 border rounded mt-4 space-y-2">
+        <div className="flex flex-col">
+          <label className="text-sm">From Date</label>
+          <input className="border p-1" type="date" value={fromDate} onChange={e => setFromDate(e.target.value)} required />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm">To Date</label>
+          <input className="border p-1" type="date" value={toDate} onChange={e => setToDate(e.target.value)} />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm">Symbols (comma separated)</label>
+          <input className="border p-1" value={symbols} onChange={e => setSymbols(e.target.value)} required />
+        </div>
+        <button className="bg-blue-500 text-white px-3 py-1 rounded" type="submit" disabled={loading}>
+          {loading ? 'Running...' : 'Run Backtest'}
+        </button>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+      </form>
+
+      {results && (
+        <div className="p-4 border rounded mt-4">
+          <h2 className="font-bold mb-2">Backtest Results</h2>
+          <pre className="text-sm whitespace-pre-wrap">{JSON.stringify(results, null, 2)}</pre>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- fetch historical bars from a public CSV and preprocess features for backtesting
- expose a `/backtest` API route and React form to run backtests
- add regression tests for backtest metrics and update dependencies

## Testing
- `ruff check market_sage_pro/backtest/engine.py market_sage_pro/data/store.py market_sage_pro/api/main.py tests/backtest/test_engine.py`
- `mypy market_sage_pro/backtest/engine.py market_sage_pro/data/store.py market_sage_pro/api/main.py tests/backtest/test_engine.py`
- `pytest`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_689977d3a298832e9168bd8bb846dc1e